### PR TITLE
add `on_pull_request` ci that builds, scans, and tests modified rocks

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -1,0 +1,14 @@
+name: On Pull Request
+
+on:
+  pull_request:
+
+jobs:
+
+  get-rocks-modified-and-build-scan-test:
+    name: Get ROCKs modified and build-scan-test them
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/get_rocks_modified_and_build_scan_test.yaml@main
+    secrets: inherit
+    with:
+      microk8s-channel: 1.25/stable
+      juju-channel: 3.1/stable


### PR DESCRIPTION
Adds calls to a shared workflow for building, scanning, and testing rocks on all pull request updates.  