### PR TITLE
fix: update envlist in oidc-authservice/tox.ini

### DIFF
--- a/oidc-authservice/tox.ini
+++ b/oidc-authservice/tox.ini
@@ -3,7 +3,7 @@
 [tox]
 skipsdist = True
 skip_missing_interpreters = True
-envlist = unit, sanity, integration
+envlist = pack, export-to-docker, sanity, integration
 
 [testenv]
 setenv =


### PR DESCRIPTION
Fixed a bug where the `oidc-authservice/tox.ini` `envlist` had the wrong environments listed.