### PR TITLE
merge fixes for rock from `ckf-1.7` to `main`

### DIFF
--- a/oidc-authservice/rockcraft.yaml
+++ b/oidc-authservice/rockcraft.yaml
@@ -1,21 +1,42 @@
+# Dockerfile: https://github.com/arrikto/oidc-authservice/blob/master/Dockerfile
 name: oidc-authservice 
 summary: Arrikto's oidc-authservice in a ROCK.
 description: "An AuthService is an HTTP Server that an API Gateway, asks if an incoming request is authorized."
 version: "ckf-1.7"
 license: Apache-2.0
 base: ubuntu@22.04
+run-user: _daemon_
 services:
   oidc-authservice:
     override: replace
     summary: "oidc-auth service"
     startup: enabled
-    user: authservice
-    command: "/bin/oidc-authservice"
+    command: "/home/authservice/oidc-authservice"
+    working-dir: "/home/authservice"
 platforms:
   amd64:
 
 parts:
-  oidc-authservice:
+  create-workingdir:
+    # Create a working directory that the running service has write access in
+    # Creating this in the same place as the upstream's working dir to enable
+    # it to be a drop-in replacement
+    # Note: This must run after anything else that writes to /home/authservice,
+    #       otherwise those operations will clobber the permissions set here
+    # TODO: Should we instead just have a nil part that does a `chown -r` on
+    # $PRIME/home/authservice?
+    after: [builder, stager]
+    plugin: nil
+    override-build: |
+      mkdir -p $CRAFT_PART_INSTALL/home/authservice
+    permissions:
+      - path: home/authservice
+        # 584792 is the _daemon_ user
+        owner: 584792
+        group: 584792
+        mode: "755"
+
+  builder:
     plugin: go
     source: https://github.com/arrikto/oidc-authservice
     source-type: git
@@ -25,26 +46,25 @@ parts:
     build-environment:
       - BUILD_IN_CONTAINER: "false"
     override-build: |
-      CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o bin/oidc-authservice
-      install -D -m755 bin/oidc-authservice ${CRAFT_PART_INSTALL}/opt/oidc-authservice/bin/oidc-authservice
-      cp -R web ${CRAFT_PART_INSTALL}/opt/oidc-authservice/web
+      CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o oidc-authservice
+      mkdir -p $CRAFT_PART_INSTALL/home/authservice
+      cp oidc-authservice $CRAFT_PART_INSTALL/home/authservice/oidc-authservice
 
-      # security requirement
-      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
-      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
-       dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
-       > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
-
-    organize:
-      opt/oidc-authservice/bin/oidc-authservice: usr/bin/oidc-authservice
-
-  # not-root user for this ROCK should be 'authservice'
-  non-root-user:
+  add-ca-certificates:
+    # This installs ca-certificates in the build env to populate our /etc/ssl/certs,
+    # then copies just the ca-certificates.crt to the final image
     plugin: nil
-    after: [oidc-authservice]
-    overlay-script: |
-      # Create a user in the $CRAFT_OVERLAY chroot
-      groupadd -R $CRAFT_OVERLAY -g 1001 authservice
-      useradd -R $CRAFT_OVERLAY -M -r -u 1001 -g authservice authservice
-    override-prime: |
-      craftctl default
+    build-packages: 
+      - ca-certificates
+    override-build: |-
+      mkdir -p $CRAFT_PART_INSTALL/etc/ssl/certs/
+      cp /etc/ssl/certs/ca-certificates.crt $CRAFT_PART_INSTALL/etc/ssl/certs/ca-certificates.crt
+
+  stager:
+    plugin: nil
+    source: https://github.com/arrikto/oidc-authservice
+    source-type: git
+    source-commit: e2364397aaf1a8119aa649989f0de87276f58cbc
+    override-build: |
+      mkdir -p $CRAFT_PART_INSTALL/home/authservice
+      cp -r web $CRAFT_PART_INSTALL/home/authservice/web

--- a/oidc-authservice/rockcraft.yaml
+++ b/oidc-authservice/rockcraft.yaml
@@ -2,7 +2,7 @@
 name: oidc-authservice 
 summary: Arrikto's oidc-authservice in a ROCK.
 description: "An AuthService is an HTTP Server that an API Gateway, asks if an incoming request is authorized."
-version: "ckf-1.7"
+version: "ckf-1.8"
 license: Apache-2.0
 base: ubuntu@22.04
 run-user: _daemon_

--- a/oidc-authservice/tests/test_rock.py
+++ b/oidc-authservice/tests/test_rock.py
@@ -15,10 +15,13 @@ import yaml
 
 from charmed_kubeflow_chisme.rock import CheckRock
 
+
 @pytest.fixture()
 def rock_test_env(tmpdir):
     """Yields a temporary directory and random docker container name, then cleans them up after."""
-    container_name = "".join([str(i) for i in random.choices(string.ascii_lowercase, k=8)])
+    container_name = "".join(
+        [str(i) for i in random.choices(string.ascii_lowercase, k=8)]
+    )
     yield tmpdir, container_name
 
     try:
@@ -26,6 +29,7 @@ def rock_test_env(tmpdir):
     except Exception:
         pass
     # tmpdir fixture we use here should clean up the other files for us
+
 
 @pytest.mark.abort_on_fail
 def test_rock(rock_test_env):
@@ -37,4 +41,15 @@ def test_rock(rock_test_env):
     LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
 
     # create ROCK filesystem
-    subprocess.run(["docker", "run", LOCAL_ROCK_IMAGE, "exec", "ls", "-la", "/bin/oidc-authservice"], check=True)
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            LOCAL_ROCK_IMAGE,
+            "exec",
+            "ls",
+            "-la",
+            "/home/authservice/oidc-authservice",
+        ],
+        check=True,
+    )


### PR DESCRIPTION
This merges fixes to the oidc-authservice rock from 1.7 back to main, so they can be reused for future versions.

Also included are fixes to the tests in main that are required for this updated rock

Closes https://github.com/canonical/oidc-authservice-rock/issues/21