### PR TITLE
ci: enable scheduled trivy scanner and report vulnerabilities as GH i…

### DIFF
--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -7,8 +7,8 @@ on:
 
 jobs:
 
-  on-push:
-    name: Get rocks modified and build-scan-test-publish them
+  scan-images:
+    name: Scan published images and report vulnerabilities
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/get-published-images-scan-and-report.yaml@main
     strategy:
       matrix:


### PR DESCRIPTION
…ssues

This workflow enables a scheduled scanner (that can also be run from a workflow dispatch) to scan images using the trivy scanner. At the same time, enables the automatic creation/edition of Github issues when a vulnerability is found.

Fixes #28