### PR TITLE
chore: bump oidc-authservice image tag ckf-1.8 -> ckf-1.9

### DIFF
--- a/oidc-authservice/rockcraft.yaml
+++ b/oidc-authservice/rockcraft.yaml
@@ -2,7 +2,7 @@
 name: oidc-authservice 
 summary: Arrikto's oidc-authservice in a rock.
 description: "An AuthService is an HTTP Server that an API Gateway, asks if an incoming request is authorized."
-version: "ckf-1.8"
+version: "ckf-1.9"
 license: Apache-2.0
 base: ubuntu@22.04
 run-user: _daemon_


### PR DESCRIPTION
Bump the rock ckf-1.8 -> ckf-1.9 in preparation for a new release.

Dear reviewers: CI is blocked because of microk8s version, https://github.com/canonical/oidc-authservice-rock/pull/35 should fix it.