### PR TITLE
ci: use microk8s strict for it to work with juju

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -12,6 +12,6 @@ jobs:
       pull-requests: read
     secrets: inherit
     with:
-      microk8s-channel: 1.31/stable
+      microk8s-channel: 1.31-strict/stable
       juju-channel: 3.6/stable
       python-version: "3.8"

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -15,6 +15,6 @@ jobs:
       pull-requests: read
     secrets: inherit
     with:
-      microk8s-channel: 1.31/stable
+      microk8s-channel: 1.31-strict/stable
       juju-channel: 3.6/stable
       python-version: "3.8"


### PR DESCRIPTION
Juju can only work with strictly confined microk8s, this commit ensures that's the installed version in the testing environment.